### PR TITLE
Added MachineName to lock file to ensure multiple machines cannot hav…

### DIFF
--- a/src/FileLock/FileLockContent.cs
+++ b/src/FileLock/FileLockContent.cs
@@ -17,6 +17,12 @@ namespace FileLock
         public long PID { get; set; }
 
         /// <summary>
+        /// The hostname of the machine
+        /// </summary>
+        [DataMember]
+        public string MachineName { get; set; }
+
+        /// <summary>
         /// The timestamp (DateTime.Now.Ticks)
         /// </summary>
         [DataMember]

--- a/src/FileLock/SimpleFileLock.cs
+++ b/src/FileLock/SimpleFileLock.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using FileLock.FileSys;
 
 namespace FileLock
 {
@@ -41,7 +40,7 @@ namespace FileLock
 
                 //This lock belongs to this process - we can reacquire the lock
                 var currentProcess = Process.GetCurrentProcess();
-                if (lockContent.PID == currentProcess.Id && lockContent.MachineName == currentProcess.MachineName)
+                if (lockContent.PID == currentProcess.Id && lockContent.MachineName == Environment.MachineName)
                 {
                     return AcquireLock();
                 }
@@ -74,7 +73,7 @@ namespace FileLock
             {
                 PID = process.Id,
                 ProcessName = process.ProcessName,
-                MachineName = process.MachineName,
+                MachineName = Environment.MachineName,
                 Timestamp = DateTime.Now.Ticks
             };
         }

--- a/src/FileLock/SimpleFileLock.cs
+++ b/src/FileLock/SimpleFileLock.cs
@@ -40,7 +40,8 @@ namespace FileLock
                 var lockWriteTime = new DateTime(lockContent.Timestamp);
 
                 //This lock belongs to this process - we can reacquire the lock
-                if (lockContent.PID == Process.GetCurrentProcess().Id)
+                var currentProcess = Process.GetCurrentProcess();
+                if (lockContent.PID == currentProcess.Id && lockContent.MachineName == currentProcess.MachineName)
                 {
                     return AcquireLock();
                 }
@@ -69,11 +70,12 @@ namespace FileLock
         protected FileLockContent CreateLockContent()
         {
             var process = Process.GetCurrentProcess();
-            return new FileLockContent()
+            return new FileLockContent
             {
                 PID = process.Id,
-                Timestamp = DateTime.Now.Ticks,
-                ProcessName = process.ProcessName
+                ProcessName = process.ProcessName,
+                MachineName = process.MachineName,
+                Timestamp = DateTime.Now.Ticks
             };
         }
 


### PR DESCRIPTION
Adding MachineName to lock file to ensure multiple processes across several machines cannot have a PID clash.  This relies on shared drives.

When using shared drives, this locking mechanism can be used well to establish active/passive services (obviously very rudimentary).  Inspired by ActiveMQ takes the same approach (by locking a shared data store and polling).
